### PR TITLE
Revert "core: Create a TestResult structure"

### DIFF
--- a/cgt-macros/src/lib.rs
+++ b/cgt-macros/src/lib.rs
@@ -10,7 +10,7 @@ pub fn cgt_assert(item: TokenStream) -> TokenStream {
 
     quote! {
         if !(#input) {
-            return cgt_core::TestResult::Failure(cgt_core::TestError::ConditionUnmet(stringify!(#input).to_string()));
+            return Err(TestError::ConditionUnmet(stringify!(#input).to_string()));
         }
     }
     .into()
@@ -22,7 +22,7 @@ pub fn cgt_assert_err(item: TokenStream) -> TokenStream {
 
     quote! {
         if !(#input).is_err() {
-            return cgt_core::TestResult::Failure(cgt_core::TestError::ResultNotOk(format!("{:#?}", (#input))));
+            return Err(TestError::ResultNotOk(format!("{:#?}", (#input))));
         }
     }
     .into()
@@ -34,7 +34,7 @@ pub fn cgt_assert_ok(item: TokenStream) -> TokenStream {
 
     quote! {
         if !(#input).is_ok() {
-            return cgt_core::TestResult::Failure(cgt_core::TestError::ResultNotOk(format!("{:#?}", (#input))));
+            return Err(TestError::ResultNotOk(format!("{:#?}", (#input))));
         }
     }
     .into()
@@ -65,7 +65,7 @@ pub fn cgt_assert_eq(input: TokenStream) -> TokenStream {
 
     quote! {
         if (#left) != (#right) {
-            return cgt_core::TestResult::Failure(cgt_core::TestError::NotEqual(format!("{:#?}", #left), format!("{:#?}", #right)));
+            return Err(TestError::NotEqual(format!("{:#?}", #left), format!("{:#?}", #right)));
         }
     }
     .into()

--- a/cgt-macros/tests/cgt_assert.rs
+++ b/cgt-macros/tests/cgt_assert.rs
@@ -1,72 +1,72 @@
-use cgt_core::{TestError, TestResult};
+use cgt_core::TestError;
 use cgt_macros::{cgt_assert, cgt_assert_eq, cgt_assert_err, cgt_assert_ok};
 
 #[test]
 fn cgt_assert_bool_true() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert!(true);
-        TestResult::Success
+        Ok(())
     }
 
-    assert_eq!(test(), TestResult::Success);
+    assert_eq!(test(), Ok(()));
 }
 
 #[test]
 fn cgt_assert_bool_false() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert!(false);
         unreachable!()
     }
 
     assert_eq!(
         test(),
-        TestResult::Failure(TestError::ConditionUnmet(String::from("false")))
+        Err(TestError::ConditionUnmet(String::from("false")))
     );
 }
 
 #[test]
 fn cgt_assert_expr_true() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert!(1 < 2);
-        TestResult::Success
+        Ok(())
     }
 
-    assert_eq!(test(), TestResult::Success);
+    assert_eq!(test(), Ok(()));
 }
 
 #[test]
 fn cgt_assert_expr_false() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert!(1 > 2);
         unreachable!()
     }
 
     assert_eq!(
         test(),
-        TestResult::Failure(TestError::ConditionUnmet(String::from("1 > 2")))
+        Err(TestError::ConditionUnmet(String::from("1 > 2")))
     );
 }
 
 #[test]
 fn cgt_assert_eq_bool_true() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert_eq!(true, true);
-        TestResult::Success
+        Ok(())
     }
 
-    assert_eq!(test(), TestResult::Success);
+    assert_eq!(test(), Ok(()));
 }
 
 #[test]
 fn cgt_assert_eq_bool_false() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert_eq!(true, false);
         unreachable!()
     }
 
     assert_eq!(
         test(),
-        TestResult::Failure(TestError::NotEqual(
+        Err(TestError::NotEqual(
             String::from("true"),
             String::from("false")
         ))
@@ -75,47 +75,47 @@ fn cgt_assert_eq_bool_false() {
 
 #[test]
 fn cgt_assert_eq_expr_true() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert_eq!(1 + 1, 2);
-        TestResult::Success
+        Ok(())
     }
 
-    assert_eq!(test(), TestResult::Success);
+    assert_eq!(test(), Ok(()));
 }
 
 #[test]
 fn cgt_assert_eq_expr_false() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert_eq!(1 + 1, 3);
         unreachable!()
     }
 
     assert_eq!(
         test(),
-        TestResult::Failure(TestError::NotEqual(String::from("2"), String::from("3")))
+        Err(TestError::NotEqual(String::from("2"), String::from("3")))
     );
 }
 
 #[test]
 fn cgt_assert_ok_true() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert_ok!(Ok::<(), TestError>(()));
-        TestResult::Success
+        Ok(())
     }
 
-    assert_eq!(test(), TestResult::Success);
+    assert_eq!(test(), Ok(()));
 }
 
 #[test]
 fn cgt_assert_ok_false() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert_ok!(Err::<(), TestError>(TestError::Unspecified));
-        TestResult::Success
+        Ok(())
     }
 
     assert_eq!(
         test(),
-        TestResult::Failure(TestError::ResultNotOk(String::from(
+        Err(TestError::ResultNotOk(String::from(
             "Err(\n    Unspecified,\n)"
         )))
     );
@@ -123,22 +123,22 @@ fn cgt_assert_ok_false() {
 
 #[test]
 fn cgt_assert_err_true() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert_err!(Err::<(), TestError>(TestError::Unspecified));
-        TestResult::Success
+        Ok(())
     }
 
-    assert_eq!(test(), TestResult::Success);
+    assert_eq!(test(), Ok(()));
 }
 #[test]
 fn cgt_assert_err_false() {
-    fn test() -> TestResult {
+    fn test() -> Result<(), TestError> {
         cgt_assert_err!(Ok::<(), TestError>(()));
-        TestResult::Success
+        Ok(())
     }
 
     assert_eq!(
         test(),
-        TestResult::Failure(TestError::ResultNotOk(String::from("Ok(\n    (),\n)")))
+        Err(TestError::ResultNotOk(String::from("Ok(\n    (),\n)")))
     );
 }

--- a/cgt-macros/tests/macrotest/cgt_assert_bool.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_bool.expanded.rs
@@ -1,7 +1,5 @@
 pub fn main() {
     if !(true) {
-        return cgt_core::TestResult::Failure(
-            cgt_core::TestError::ConditionUnmet("true".to_string()),
-        );
+        return Err(TestError::ConditionUnmet("true".to_string()));
     }
 }

--- a/cgt-macros/tests/macrotest/cgt_assert_condition.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_condition.expanded.rs
@@ -1,7 +1,5 @@
 pub fn main() {
     if !(1 > 2) {
-        return cgt_core::TestResult::Failure(
-            cgt_core::TestError::ConditionUnmet("1 > 2".to_string()),
-        );
+        return Err(TestError::ConditionUnmet("1 > 2".to_string()));
     }
 }

--- a/cgt-macros/tests/macrotest/cgt_assert_eq_bool.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_eq_bool.expanded.rs
@@ -1,7 +1,7 @@
 pub fn main() {
     if (true) != (true) {
-        return cgt_core::TestResult::Failure(
-            cgt_core::TestError::NotEqual(
+        return Err(
+            TestError::NotEqual(
                 {
                     let res = ::alloc::fmt::format(format_args!("{0:#?}", true));
                     res

--- a/cgt-macros/tests/macrotest/cgt_assert_eq_condition.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_eq_condition.expanded.rs
@@ -1,7 +1,7 @@
 pub fn main() {
     if (2 > 1) != (true) {
-        return cgt_core::TestResult::Failure(
-            cgt_core::TestError::NotEqual(
+        return Err(
+            TestError::NotEqual(
                 {
                     let res = ::alloc::fmt::format(format_args!("{0:#?}", 2 > 1));
                     res

--- a/cgt-macros/tests/macrotest/cgt_assert_eq_expr.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_eq_expr.expanded.rs
@@ -1,7 +1,7 @@
 pub fn main() {
     if (1 + 2) != (3) {
-        return cgt_core::TestResult::Failure(
-            cgt_core::TestError::NotEqual(
+        return Err(
+            TestError::NotEqual(
                 {
                     let res = ::alloc::fmt::format(format_args!("{0:#?}", 1 + 2));
                     res

--- a/cgt-macros/tests/trybuild/failures/cgt_test_attr.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_attr.rs
@@ -1,5 +1,5 @@
 #[cgt_macros::cgt_test(attribute)]
-fn test() -> cgt_core::TestResult {
+fn test() -> Result<(), cgt_core::TestError> {
     Ok(())
 }
 

--- a/cgt-macros/tests/trybuild/failures/cgt_test_fd_empty_caps.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_fd_empty_caps.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_fd(capabilities)]
-fn test(_: std::os::fd::BorrowedFd<'_>) -> cgt_core::TestResult {
-    cgt_core::TestResult::Success
+fn test(_: std::os::fd::BorrowedFd<'_>) -> Result<(), cgt_core::TestError> {
+    Ok(())
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_fd_unknown_attr.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_fd_unknown_attr.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_fd(unknown)]
-fn test(_: std::os::fd::BorrowedFd<'_>) -> cgt_core::TestResult {
-    cgt_core::TestResult::Success
+fn test(_: std::os::fd::BorrowedFd<'_>) -> Result<(), TestResult> {
+    Ok(())
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_fd_unknown_caps.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_fd_unknown_caps.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_fd(capabilities=[Unknown])]
-fn test(_: std::os::fd::BorrowedFd<'_>) -> cgt_core::TestResult {
-    cgt_core::TestResult::Success
+fn test(_: std::os::fd::BorrowedFd<'_>) -> Result<(), cgt_core::TestError> {
+    Ok(())
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_fd_wrong_caps_type.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_fd_wrong_caps_type.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_fd(capabilities = "Wrong")]
-fn test(_: std::os::fd::BorrowedFd<'_>) -> cgt_core::TestResult {
-    cgt_core::TestResult::Success
+fn test(_: std::os::fd::BorrowedFd<'_>) -> Result<(), TestResult> {
+    Ok(())
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_path_attr.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_path_attr.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_path(attribute)]
-fn test(_: &Path) -> cgt_core::TestResult {
-    cgt_core::TestResult::Success
+fn test(_: &Path) -> Result<(), cgt_core::TestError> {
+    Ok(())
 }
 
 fn main() {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@
 
 use colored::Colorize;
 
-use cgt_core::{run_all, DeviceSpecifier, RunResult, Test, TestResult, TestResultWriter};
+use cgt_core::{run_all, DeviceSpecifier, RunResult, Test, TestError, TestResultWriter};
 
 mod tests;
 
@@ -34,13 +34,13 @@ impl TestResultWriter for ConsoleResultWriter {
         self.num_tests += 1;
     }
 
-    fn write_result(&mut self, _test: &Test, res: &TestResult) {
+    fn write_result(&mut self, _test: &Test, res: &Result<(), TestError>) {
         match res {
-            TestResult::Success => {
+            Ok(()) => {
                 println!("\t{}", "✔".green().bold());
                 self.successful_tests += 1;
             }
-            TestResult::Failure(e) => {
+            Err(e) => {
                 println!("\t{}", format!("✘ -> {e}").red().bold());
                 self.failing_tests += 1;
             }

--- a/src/tests/dummy.rs
+++ b/src/tests/dummy.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
 #[cgt_test]
-fn test_dummy() -> TestResult {
-    TestResult::Success
+fn test_dummy() -> Result<(), TestError> {
+    Ok(())
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,7 +5,7 @@ mod prelude {
         path::Path,
     };
 
-    pub use cgt_core::TestResult;
+    pub use cgt_core::TestError;
     pub use cgt_macros::*;
     pub use drm_helpers::*;
     pub use drm_uapi::{ClientCapability::*, *};


### PR DESCRIPTION
This reverts commit a98d01f36f3ae038e4231cf67c63f8009497259c.

Having a custom Result type doesn't allow to use the ? operator for now which is fairly inconvenient.

When the API will have stabilized we will be able to come back to that.