### PR TITLE
Create a Result Enum Type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
       - name: Build
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
       - name: Install cargo-expand

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           components: clippy
           override: true
 

--- a/cgt-core/src/lib.rs
+++ b/cgt-core/src/lib.rs
@@ -61,9 +61,9 @@ impl From<nix::Error> for TestError {
 
 #[derive(Clone, Debug)]
 pub enum TestFunction {
-    NoArg(fn() -> Result<(), TestError>),
-    WithFd(fn(BorrowedFd) -> Result<(), TestError>),
-    WithPath(fn(&Path) -> Result<(), TestError>),
+    NoArg(fn() -> TestResult),
+    WithFd(fn(BorrowedFd) -> TestResult),
+    WithPath(fn(&Path) -> TestResult),
 }
 
 #[derive(Clone, Debug)]
@@ -75,10 +75,48 @@ pub struct Test {
     pub client_capabilities: [Option<ClientCapability>; 8],
 }
 
+#[derive(PartialEq)]
+pub enum InnerResult<E> {
+    Success,
+    Failure(E),
+}
+
+impl<E> InnerResult<E> {
+    pub fn and(self, res: InnerResult<E>) -> InnerResult<E> {
+        match self {
+            InnerResult::Success => res,
+            InnerResult::Failure(_) => self,
+        }
+    }
+}
+
+impl<U, E, F> From<Result<U, E>> for InnerResult<F>
+where
+    F: From<E>,
+{
+    fn from(value: Result<U, E>) -> Self {
+        match value {
+            Ok(_) => Self::Success,
+            Err(e) => Self::Failure(Into::<F>::into(e)),
+        }
+    }
+}
+
+pub type TestResult = InnerResult<TestError>;
+
+impl std::fmt::Debug for TestResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Self::Success => write!(f, "Success"),
+            Self::Failure(e) => write!(f, "Failure: {}", e),
+        }
+    }
+}
+
 pub trait TestResultWriter {
     fn new() -> Self;
     fn write_test(&mut self, test: &Test);
-    fn write_result(&mut self, test: &Test, res: &Result<(), TestError>);
+    fn write_result(&mut self, test: &Test, res: &TestResult);
 
     fn start_suite(&mut self, _name: &str, _tests: &[Test]) {}
     fn end_suite(&mut self) {}
@@ -151,11 +189,11 @@ pub enum RunResult {
     Failure,
 }
 
-impl<U, E> From<Result<U, E>> for RunResult {
-    fn from(value: Result<U, E>) -> Self {
+impl<E> From<InnerResult<E>> for RunResult {
+    fn from(value: InnerResult<E>) -> Self {
         match value {
-            Ok(_) => RunResult::Success,
-            Err(_) => RunResult::Failure,
+            InnerResult::Success => RunResult::Success,
+            InnerResult::Failure(_) => RunResult::Failure,
         }
     }
 }
@@ -169,8 +207,33 @@ impl Termination for RunResult {
     }
 }
 
+fn run_one_fd_test(test: &Test, path: &Path, f: fn(BorrowedFd<'_>) -> TestResult) -> TestResult {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(e) => return TestResult::Failure(e.into()),
+    };
+
+    let fd = file.as_fd();
+    if test.master {
+        let res = set_master(fd);
+        if res.is_err() {
+            return res.into();
+        }
+    }
+
+    for cap in test.client_capabilities.into_iter().flatten() {
+        let res = set_client_capability(fd, cap);
+
+        if res.is_err() {
+            return res.into();
+        }
+    }
+
+    f(file.as_fd())
+}
+
 pub fn run_all(writer: &mut impl TestResultWriter, dev: DeviceSpecifier) -> RunResult {
-    let mut result = Ok(());
+    let mut result = TestResult::Success;
 
     let path = find_device(dev).unwrap();
 
@@ -182,21 +245,7 @@ pub fn run_all(writer: &mut impl TestResultWriter, dev: DeviceSpecifier) -> RunR
 
             let res = match test.test_fn {
                 TestFunction::NoArg(f) => f(),
-                TestFunction::WithFd(f) => {
-                    File::open(&path).map_err(|e| e.into()).and_then(|file| {
-                        let fd = file.as_fd();
-
-                        if test.master {
-                            set_master(fd)?;
-                        }
-
-                        for cap in test.client_capabilities.into_iter().flatten() {
-                            set_client_capability(fd, cap)?;
-                        }
-
-                        f(file.as_fd())
-                    })
-                }
+                TestFunction::WithFd(f) => run_one_fd_test(&test, &path, f),
                 TestFunction::WithPath(f) => f(&path),
             };
 

--- a/cgt-macros/src/lib.rs
+++ b/cgt-macros/src/lib.rs
@@ -10,7 +10,7 @@ pub fn cgt_assert(item: TokenStream) -> TokenStream {
 
     quote! {
         if !(#input) {
-            return Err(TestError::ConditionUnmet(stringify!(#input).to_string()));
+            return cgt_core::TestResult::Failure(cgt_core::TestError::ConditionUnmet(stringify!(#input).to_string()));
         }
     }
     .into()
@@ -22,7 +22,7 @@ pub fn cgt_assert_err(item: TokenStream) -> TokenStream {
 
     quote! {
         if !(#input).is_err() {
-            return Err(TestError::ResultNotOk(format!("{:#?}", (#input))));
+            return cgt_core::TestResult::Failure(cgt_core::TestError::ResultNotOk(format!("{:#?}", (#input))));
         }
     }
     .into()
@@ -34,7 +34,7 @@ pub fn cgt_assert_ok(item: TokenStream) -> TokenStream {
 
     quote! {
         if !(#input).is_ok() {
-            return Err(TestError::ResultNotOk(format!("{:#?}", (#input))));
+            return cgt_core::TestResult::Failure(cgt_core::TestError::ResultNotOk(format!("{:#?}", (#input))));
         }
     }
     .into()
@@ -65,7 +65,7 @@ pub fn cgt_assert_eq(input: TokenStream) -> TokenStream {
 
     quote! {
         if (#left) != (#right) {
-            return Err(TestError::NotEqual(format!("{:#?}", #left), format!("{:#?}", #right)));
+            return cgt_core::TestResult::Failure(cgt_core::TestError::NotEqual(format!("{:#?}", #left), format!("{:#?}", #right)));
         }
     }
     .into()

--- a/cgt-macros/tests/cgt_assert.rs
+++ b/cgt-macros/tests/cgt_assert.rs
@@ -1,72 +1,72 @@
-use cgt_core::TestError;
+use cgt_core::{TestError, TestResult};
 use cgt_macros::{cgt_assert, cgt_assert_eq, cgt_assert_err, cgt_assert_ok};
 
 #[test]
 fn cgt_assert_bool_true() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert!(true);
-        Ok(())
+        TestResult::Success
     }
 
-    assert_eq!(test(), Ok(()));
+    assert_eq!(test(), TestResult::Success);
 }
 
 #[test]
 fn cgt_assert_bool_false() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert!(false);
         unreachable!()
     }
 
     assert_eq!(
         test(),
-        Err(TestError::ConditionUnmet(String::from("false")))
+        TestResult::Failure(TestError::ConditionUnmet(String::from("false")))
     );
 }
 
 #[test]
 fn cgt_assert_expr_true() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert!(1 < 2);
-        Ok(())
+        TestResult::Success
     }
 
-    assert_eq!(test(), Ok(()));
+    assert_eq!(test(), TestResult::Success);
 }
 
 #[test]
 fn cgt_assert_expr_false() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert!(1 > 2);
         unreachable!()
     }
 
     assert_eq!(
         test(),
-        Err(TestError::ConditionUnmet(String::from("1 > 2")))
+        TestResult::Failure(TestError::ConditionUnmet(String::from("1 > 2")))
     );
 }
 
 #[test]
 fn cgt_assert_eq_bool_true() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert_eq!(true, true);
-        Ok(())
+        TestResult::Success
     }
 
-    assert_eq!(test(), Ok(()));
+    assert_eq!(test(), TestResult::Success);
 }
 
 #[test]
 fn cgt_assert_eq_bool_false() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert_eq!(true, false);
         unreachable!()
     }
 
     assert_eq!(
         test(),
-        Err(TestError::NotEqual(
+        TestResult::Failure(TestError::NotEqual(
             String::from("true"),
             String::from("false")
         ))
@@ -75,47 +75,47 @@ fn cgt_assert_eq_bool_false() {
 
 #[test]
 fn cgt_assert_eq_expr_true() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert_eq!(1 + 1, 2);
-        Ok(())
+        TestResult::Success
     }
 
-    assert_eq!(test(), Ok(()));
+    assert_eq!(test(), TestResult::Success);
 }
 
 #[test]
 fn cgt_assert_eq_expr_false() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert_eq!(1 + 1, 3);
         unreachable!()
     }
 
     assert_eq!(
         test(),
-        Err(TestError::NotEqual(String::from("2"), String::from("3")))
+        TestResult::Failure(TestError::NotEqual(String::from("2"), String::from("3")))
     );
 }
 
 #[test]
 fn cgt_assert_ok_true() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert_ok!(Ok::<(), TestError>(()));
-        Ok(())
+        TestResult::Success
     }
 
-    assert_eq!(test(), Ok(()));
+    assert_eq!(test(), TestResult::Success);
 }
 
 #[test]
 fn cgt_assert_ok_false() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert_ok!(Err::<(), TestError>(TestError::Unspecified));
-        Ok(())
+        TestResult::Success
     }
 
     assert_eq!(
         test(),
-        Err(TestError::ResultNotOk(String::from(
+        TestResult::Failure(TestError::ResultNotOk(String::from(
             "Err(\n    Unspecified,\n)"
         )))
     );
@@ -123,22 +123,22 @@ fn cgt_assert_ok_false() {
 
 #[test]
 fn cgt_assert_err_true() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert_err!(Err::<(), TestError>(TestError::Unspecified));
-        Ok(())
+        TestResult::Success
     }
 
-    assert_eq!(test(), Ok(()));
+    assert_eq!(test(), TestResult::Success);
 }
 #[test]
 fn cgt_assert_err_false() {
-    fn test() -> Result<(), TestError> {
+    fn test() -> TestResult {
         cgt_assert_err!(Ok::<(), TestError>(()));
-        Ok(())
+        TestResult::Success
     }
 
     assert_eq!(
         test(),
-        Err(TestError::ResultNotOk(String::from("Ok(\n    (),\n)")))
+        TestResult::Failure(TestError::ResultNotOk(String::from("Ok(\n    (),\n)")))
     );
 }

--- a/cgt-macros/tests/macrotest/cgt_assert_bool.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_bool.expanded.rs
@@ -1,5 +1,7 @@
 pub fn main() {
     if !(true) {
-        return Err(TestError::ConditionUnmet("true".to_string()));
+        return cgt_core::TestResult::Failure(
+            cgt_core::TestError::ConditionUnmet("true".to_string()),
+        );
     }
 }

--- a/cgt-macros/tests/macrotest/cgt_assert_condition.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_condition.expanded.rs
@@ -1,5 +1,7 @@
 pub fn main() {
     if !(1 > 2) {
-        return Err(TestError::ConditionUnmet("1 > 2".to_string()));
+        return cgt_core::TestResult::Failure(
+            cgt_core::TestError::ConditionUnmet("1 > 2".to_string()),
+        );
     }
 }

--- a/cgt-macros/tests/macrotest/cgt_assert_eq_bool.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_eq_bool.expanded.rs
@@ -1,7 +1,7 @@
 pub fn main() {
     if (true) != (true) {
-        return Err(
-            TestError::NotEqual(
+        return cgt_core::TestResult::Failure(
+            cgt_core::TestError::NotEqual(
                 {
                     let res = ::alloc::fmt::format(format_args!("{0:#?}", true));
                     res

--- a/cgt-macros/tests/macrotest/cgt_assert_eq_condition.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_eq_condition.expanded.rs
@@ -1,7 +1,7 @@
 pub fn main() {
     if (2 > 1) != (true) {
-        return Err(
-            TestError::NotEqual(
+        return cgt_core::TestResult::Failure(
+            cgt_core::TestError::NotEqual(
                 {
                     let res = ::alloc::fmt::format(format_args!("{0:#?}", 2 > 1));
                     res

--- a/cgt-macros/tests/macrotest/cgt_assert_eq_expr.expanded.rs
+++ b/cgt-macros/tests/macrotest/cgt_assert_eq_expr.expanded.rs
@@ -1,7 +1,7 @@
 pub fn main() {
     if (1 + 2) != (3) {
-        return Err(
-            TestError::NotEqual(
+        return cgt_core::TestResult::Failure(
+            cgt_core::TestError::NotEqual(
                 {
                     let res = ::alloc::fmt::format(format_args!("{0:#?}", 1 + 2));
                     res

--- a/cgt-macros/tests/trybuild/failures/cgt_test_attr.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_attr.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test(attribute)]
-fn test() -> Result<(), cgt_core::TestError> {
-    Ok(())
+fn test() -> cgt_core::TestResult {
+    cgt_core::TestResult::Success
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_fd_empty_caps.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_fd_empty_caps.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_fd(capabilities)]
-fn test(_: std::os::fd::BorrowedFd<'_>) -> Result<(), cgt_core::TestError> {
-    Ok(())
+fn test(_: std::os::fd::BorrowedFd<'_>) -> cgt_core::TestResult {
+    cgt_core::TestResult::Success
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_fd_unknown_attr.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_fd_unknown_attr.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_fd(unknown)]
-fn test(_: std::os::fd::BorrowedFd<'_>) -> Result<(), TestResult> {
-    Ok(())
+fn test(_: std::os::fd::BorrowedFd<'_>) -> cgt_core::TestResult {
+    cgt_core::TestResult::Success
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_fd_unknown_caps.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_fd_unknown_caps.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_fd(capabilities=[Unknown])]
-fn test(_: std::os::fd::BorrowedFd<'_>) -> Result<(), cgt_core::TestError> {
-    Ok(())
+fn test(_: std::os::fd::BorrowedFd<'_>) -> cgt_core::TestResult {
+    cgt_core::TestResult::Success
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_fd_wrong_caps_type.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_fd_wrong_caps_type.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_fd(capabilities = "Wrong")]
-fn test(_: std::os::fd::BorrowedFd<'_>) -> Result<(), TestResult> {
-    Ok(())
+fn test(_: std::os::fd::BorrowedFd<'_>) -> cgt_core::TestResult {
+    cgt_core::TestResult::Success
 }
 
 fn main() {}

--- a/cgt-macros/tests/trybuild/failures/cgt_test_path_attr.rs
+++ b/cgt-macros/tests/trybuild/failures/cgt_test_path_attr.rs
@@ -1,6 +1,6 @@
 #[cgt_macros::cgt_test_with_path(attribute)]
-fn test(_: &std::path::Path) -> Result<(), cgt_core::TestError> {
-    Ok(())
+fn test(_: &std::path::Path) -> cgt_core::TestResult {
+    cgt_core::TestResult::Success
 }
 
 fn main() {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@
 
 use colored::Colorize;
 
-use cgt_core::{run_all, DeviceSpecifier, RunResult, Test, TestError, TestResultWriter};
+use cgt_core::{run_all, DeviceSpecifier, RunResult, Test, TestResult, TestResultWriter};
 
 mod tests;
 
@@ -34,13 +34,13 @@ impl TestResultWriter for ConsoleResultWriter {
         self.num_tests += 1;
     }
 
-    fn write_result(&mut self, _test: &Test, res: &Result<(), TestError>) {
+    fn write_result(&mut self, _test: &Test, res: &TestResult) {
         match res {
-            Ok(()) => {
+            TestResult::Success => {
                 println!("\t{}", "✔".green().bold());
                 self.successful_tests += 1;
             }
-            Err(e) => {
+            TestResult::Failure(e) => {
                 println!("\t{}", format!("✘ -> {e}").red().bold());
                 self.failing_tests += 1;
             }

--- a/src/tests/dummy.rs
+++ b/src/tests/dummy.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
 #[cgt_test]
-fn test_dummy() -> Result<(), TestError> {
-    Ok(())
+fn test_dummy() -> TestResult {
+    TestResult::Success
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,7 +5,7 @@ mod prelude {
         path::Path,
     };
 
-    pub use cgt_core::TestError;
+    pub use cgt_core::TestResult;
     pub use cgt_macros::*;
     pub use drm_helpers::*;
     pub use drm_uapi::{ClientCapability::*, *};


### PR DESCRIPTION
This is a second attempt at providing a custom Result type for our tests.

In order to use the ? operator, we need the [`try_trait_v2`](https://github.com/rust-lang/rust/issues/84277) feature to stabilize so it will take some time.